### PR TITLE
feat: project CRUD — API, migrations, and UI (#185)

### DIFF
--- a/fleet-ui/src/App.tsx
+++ b/fleet-ui/src/App.tsx
@@ -25,6 +25,7 @@ import { Login, Signup } from './pages/Auth';
 import { Settings } from './pages/Settings';
 import { SubmitTask } from './pages/SubmitTask';
 import { Projects } from './pages/Projects';
+import { ProjectDetail } from './pages/ProjectDetail';
 import { Chat } from './pages/Chat';
 import { Admin } from './pages/Admin';
 import { lightTheme, darkTheme } from './theme';
@@ -261,6 +262,7 @@ export default function App() {
               <Route path="/submit" element={<ProtectedRoute><SubmitTask /></ProtectedRoute>} />
               <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
               <Route path="/projects" element={<ProtectedRoute><Projects /></ProtectedRoute>} />
+              <Route path="/projects/:projectId" element={<ProtectedRoute><ProjectDetail /></ProtectedRoute>} />
               <Route path="/chat" element={<ProtectedRoute><Chat /></ProtectedRoute>} />
               <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
             </Routes>

--- a/fleet-ui/src/pages/ProjectDetail/ProjectDetail.tsx
+++ b/fleet-ui/src/pages/ProjectDetail/ProjectDetail.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Box, Button, Chip, CircularProgress, Container, Divider,
+  Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
+import { supabase } from '../../lib/supabase';
+
+interface Project {
+  id: string;
+  name: string;
+  repo_path: string;
+  languages: string[];
+  frameworks: string[];
+  test_frameworks: string[];
+  databases: string[];
+  has_ci: boolean;
+  has_docker: boolean;
+  estimated_loc: number;
+  created_at: string;
+}
+
+interface Task {
+  id: string;
+  description: string;
+  status: string;
+  created_at: string;
+}
+
+const STATUS_COLOR: Record<string, 'default' | 'warning' | 'info' | 'success' | 'error'> = {
+  queued: 'default',
+  running: 'info',
+  completed: 'success',
+  failed: 'error',
+  cancelled: 'default',
+};
+
+export default function ProjectDetail() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+  const [project, setProject] = useState<Project | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!projectId) return;
+    Promise.all([
+      supabase.from('projects').select('*').eq('id', projectId).single(),
+      supabase.from('tasks').select('id, description, status, created_at').eq('project_id', projectId).order('created_at', { ascending: false }),
+    ]).then(([{ data: proj }, { data: taskData }]) => {
+      if (proj) setProject(proj);
+      if (taskData) setTasks(taskData);
+      setLoading(false);
+    });
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!project) {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography color="error" data-testid="project-not-found">Project not found.</Typography>
+        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/projects')} sx={{ mt: 2 }}>
+          Back to Projects
+        </Button>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      {/* Header */}
+      <Box display="flex" alignItems="center" gap={1} mb={3}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate('/projects')}
+          size="small"
+          data-testid="back-to-projects"
+        >
+          Projects
+        </Button>
+        <Typography color="text.disabled">/</Typography>
+        <Typography variant="h5" sx={{ fontFamily: '"Fira Code"' }} data-testid="project-detail-name">
+          {project.name}
+        </Typography>
+      </Box>
+
+      {/* Metadata */}
+      <Box mb={3}>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {project.repo_path}
+        </Typography>
+        <Stack direction="row" flexWrap="wrap" gap={0.5} mb={1}>
+          {project.languages?.map((l) => <Chip key={l} label={l} size="small" color="primary" />)}
+          {project.frameworks?.map((f) => <Chip key={f} label={f} size="small" variant="outlined" />)}
+          {project.test_frameworks?.map((t) => <Chip key={t} label={t} size="small" variant="outlined" />)}
+          {project.databases?.map((d) => <Chip key={d} label={d} size="small" variant="outlined" />)}
+          {project.has_ci && <Chip label="CI" size="small" color="success" variant="outlined" />}
+          {project.has_docker && <Chip label="Docker" size="small" color="info" variant="outlined" />}
+        </Stack>
+        {project.estimated_loc > 0 && (
+          <Typography variant="caption" color="text.secondary">
+            ~{project.estimated_loc.toLocaleString()} LOC
+          </Typography>
+        )}
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      {/* Tasks */}
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="h6">Tasks ({tasks.length})</Typography>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<RocketLaunchOutlinedIcon />}
+          onClick={() => navigate(`/submit?project_id=${projectId}`)}
+          data-testid="submit-task-for-project"
+        >
+          Submit Task
+        </Button>
+      </Box>
+
+      {tasks.length === 0 ? (
+        <Typography color="text.secondary" data-testid="no-tasks">
+          No tasks yet. Submit one to get started.
+        </Typography>
+      ) : (
+        <Table size="small" data-testid="project-tasks-table">
+          <TableHead>
+            <TableRow>
+              <TableCell>Description</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Created</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {tasks.map((t) => (
+              <TableRow
+                key={t.id}
+                hover
+                sx={{ cursor: 'pointer' }}
+                onClick={() => navigate(`/tasks/${t.id}`)}
+                data-testid={`task-row-${t.id}`}
+              >
+                <TableCell sx={{ maxWidth: 400 }}>
+                  <Typography variant="body2" noWrap>{t.description}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={t.status}
+                    size="small"
+                    color={STATUS_COLOR[t.status] ?? 'default'}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" color="text.secondary">
+                    {new Date(t.created_at).toLocaleString()}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Container>
+  );
+}

--- a/fleet-ui/src/pages/ProjectDetail/index.ts
+++ b/fleet-ui/src/pages/ProjectDetail/index.ts
@@ -1,0 +1,1 @@
+export { default as ProjectDetail } from './ProjectDetail';

--- a/fleet-ui/src/pages/Projects/Projects.tsx
+++ b/fleet-ui/src/pages/Projects/Projects.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
-  Box, Button, Card, CardContent, Chip, Container, Dialog, DialogActions,
-  DialogContent, DialogTitle, Grid, Step, StepLabel, Stepper,
-  TextField, Typography,
+  Box, Button, Card, CardActionArea, CardContent, Chip, Container,
+  Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle,
+  Grid, IconButton, Step, StepLabel, Stepper, TextField, Tooltip, Typography,
 } from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -22,10 +25,18 @@ const WIZARD_STEPS = ['Repository', 'Detected Stack', 'Agents', 'Confirm'];
 
 export default function Projects() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [projects, setProjects] = useState<Project[]>([]);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [activeStep, setActiveStep] = useState(0);
   const [repoPath, setRepoPath] = useState('');
+
+  // Edit state
+  const [editProject, setEditProject] = useState<Project | null>(null);
+  const [editName, setEditName] = useState('');
+
+  // Delete state
+  const [deleteProject, setDeleteProject] = useState<Project | null>(null);
 
   const load = async () => {
     const { data } = await supabase.from('projects').select('*').order('created_at', { ascending: false });
@@ -49,6 +60,20 @@ export default function Projects() {
     load();
   };
 
+  const handleEditSave = async () => {
+    if (!editProject || !editName.trim()) return;
+    await supabase.from('projects').update({ name: editName.trim() }).eq('id', editProject.id);
+    setEditProject(null);
+    load();
+  };
+
+  const handleDelete = async () => {
+    if (!deleteProject) return;
+    await supabase.from('projects').delete().eq('id', deleteProject.id);
+    setDeleteProject(null);
+    load();
+  };
+
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
@@ -61,20 +86,44 @@ export default function Projects() {
       <Grid container spacing={2}>
         {projects.map((p) => (
           <Grid size={{ xs: 12, sm: 6, md: 4 }} key={p.id}>
-            <Card data-testid={`project-card-${p.name}`}>
-              <CardContent>
-                <Typography variant="h6" sx={{ fontFamily: '"Fira Code"' }}>{p.name}</Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>{p.repo_path}</Typography>
-                <Box display="flex" gap={0.5} flexWrap="wrap">
-                  {p.languages?.map((l) => <Chip key={l} label={l} size="small" color="primary" />)}
-                  {p.frameworks?.map((f) => <Chip key={f} label={f} size="small" variant="outlined" />)}
-                </Box>
-                {p.estimated_loc > 0 && (
-                  <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                    ~{p.estimated_loc.toLocaleString()} LOC
-                  </Typography>
-                )}
-              </CardContent>
+            <Card data-testid={`project-card-${p.name}`} sx={{ position: 'relative' }}>
+              <CardActionArea onClick={() => navigate(`/projects/${p.id}`)} data-testid={`project-card-link-${p.name}`}>
+                <CardContent sx={{ pb: '40px !important' }}>
+                  <Typography variant="h6" sx={{ fontFamily: '"Fira Code"' }}>{p.name}</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>{p.repo_path}</Typography>
+                  <Box display="flex" gap={0.5} flexWrap="wrap">
+                    {p.languages?.map((l) => <Chip key={l} label={l} size="small" color="primary" />)}
+                    {p.frameworks?.map((f) => <Chip key={f} label={f} size="small" variant="outlined" />)}
+                  </Box>
+                  {p.estimated_loc > 0 && (
+                    <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                      ~{p.estimated_loc.toLocaleString()} LOC
+                    </Typography>
+                  )}
+                </CardContent>
+              </CardActionArea>
+              {/* Action buttons — outside CardActionArea to avoid nested interactive elements */}
+              <Box sx={{ position: 'absolute', bottom: 6, right: 6, display: 'flex', gap: 0.5 }}>
+                <Tooltip title="Rename">
+                  <IconButton
+                    size="small"
+                    data-testid={`edit-project-${p.name}`}
+                    onClick={(e) => { e.stopPropagation(); setEditProject(p); setEditName(p.name); }}
+                  >
+                    <EditOutlinedIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete">
+                  <IconButton
+                    size="small"
+                    color="error"
+                    data-testid={`delete-project-${p.name}`}
+                    onClick={(e) => { e.stopPropagation(); setDeleteProject(p); }}
+                  >
+                    <DeleteOutlineIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Box>
             </Card>
           </Grid>
         ))}
@@ -149,6 +198,45 @@ export default function Projects() {
               Save Project
             </Button>
           )}
+        </DialogActions>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={!!editProject} onClose={() => setEditProject(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Rename Project</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            label="Project Name"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            sx={{ mt: 1 }}
+            data-testid="edit-project-name-input"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditProject(null)}>Cancel</Button>
+          <Button variant="contained" onClick={handleEditSave} disabled={!editName.trim()} data-testid="edit-project-save">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={!!deleteProject} onClose={() => setDeleteProject(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete Project</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete <strong>{deleteProject?.name}</strong>?
+            Existing tasks will be unlinked but not deleted.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteProject(null)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={handleDelete} data-testid="confirm-delete-project">
+            Delete
+          </Button>
         </DialogActions>
       </Dialog>
     </Container>

--- a/fleet-ui/src/pages/SubmitTask/SubmitTask.tsx
+++ b/fleet-ui/src/pages/SubmitTask/SubmitTask.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Alert, Box, Button, Container, FormControl, InputLabel, MenuItem,
   Select, TextField, Typography,
@@ -12,13 +12,22 @@ interface Workflow {
   name: string;
 }
 
+interface Project {
+  id: string;
+  name: string;
+  repo_path: string;
+}
+
 export default function SubmitTask() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [repo, setRepo] = useState('');
   const [description, setDescription] = useState('');
   const [workflowId, setWorkflowId] = useState('');
+  const [projectId, setProjectId] = useState(searchParams.get('project_id') ?? '');
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -29,7 +38,18 @@ export default function SubmitTask() {
         if (data.length > 0) setWorkflowId(data[0].id);
       }
     });
+    supabase.from('projects').select('id, name, repo_path').order('created_at', { ascending: false }).then(({ data }) => {
+      if (data) setProjects(data);
+    });
   }, []);
+
+  // Pre-fill repo path when a project is selected
+  useEffect(() => {
+    if (projectId) {
+      const proj = projects.find((p) => p.id === projectId);
+      if (proj && !repo) setRepo(proj.repo_path);
+    }
+  }, [projectId, projects]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -49,6 +69,7 @@ export default function SubmitTask() {
           repo,
           description,
           workflow_id: workflowId,
+          project_id: projectId || null,
         }),
       });
 
@@ -75,6 +96,21 @@ export default function SubmitTask() {
       {error && <Alert severity="error" sx={{ mb: 2 }} data-testid="submit-error">{error}</Alert>}
 
       <Box component="form" onSubmit={handleSubmit}>
+        {projects.length > 0 && (
+          <FormControl fullWidth margin="normal" data-testid="project-select">
+            <InputLabel>Project (optional)</InputLabel>
+            <Select
+              value={projectId}
+              label="Project (optional)"
+              onChange={(e) => setProjectId(e.target.value)}
+            >
+              <MenuItem value=""><em>None</em></MenuItem>
+              {projects.map((p) => (
+                <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
         <TextField
           label="Repository Path"
           fullWidth

--- a/src/agent_fleet/api/routes/projects.py
+++ b/src/agent_fleet/api/routes/projects.py
@@ -1,0 +1,100 @@
+"""Project CRUD routes backed by Supabase."""
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+
+from agent_fleet.api.deps import get_current_user, get_supabase_client
+from agent_fleet.api.schemas.projects import (
+    ProjectCreateRequest,
+    ProjectDetailResponse,
+    ProjectResponse,
+    ProjectUpdateRequest,
+)
+from agent_fleet.store.supabase_repo import SupabaseProjectRepository, SupabaseTaskRepository
+
+logger = structlog.get_logger()
+router = APIRouter(prefix="/api/v1/projects", tags=["projects"])
+
+
+def _get_repo() -> SupabaseProjectRepository:
+    client = get_supabase_client()
+    return SupabaseProjectRepository(client)
+
+
+def _get_task_repo() -> SupabaseTaskRepository:
+    client = get_supabase_client()
+    return SupabaseTaskRepository(client)
+
+
+@router.get("")
+async def list_projects(
+    user: dict = Depends(get_current_user),
+    repo: SupabaseProjectRepository = Depends(_get_repo),
+) -> list[ProjectResponse]:
+    """List all projects for the current user."""
+    projects = repo.list_by_user(user["id"])
+    return [ProjectResponse(**p) for p in projects]
+
+
+@router.get("/{project_id}")
+async def get_project(
+    project_id: str,
+    user: dict = Depends(get_current_user),
+    repo: SupabaseProjectRepository = Depends(_get_repo),
+    task_repo: SupabaseTaskRepository = Depends(_get_task_repo),
+) -> ProjectDetailResponse:
+    """Get project detail with task count."""
+    project = repo.get(project_id)
+    if not project or project.get("user_id") != user["id"]:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    task_count = task_repo.count_by_project(project_id)
+    return ProjectDetailResponse(**project, task_count=task_count)
+
+
+@router.post("", status_code=201)
+async def create_project(
+    request: ProjectCreateRequest,
+    user: dict = Depends(get_current_user),
+    repo: SupabaseProjectRepository = Depends(_get_repo),
+) -> ProjectResponse:
+    """Create a new project."""
+    project = repo.create(user["id"], request.model_dump())
+    logger.info("project_created", project_id=project["id"], user_id=user["id"])
+    return ProjectResponse(**project)
+
+
+@router.put("/{project_id}")
+async def update_project(
+    project_id: str,
+    request: ProjectUpdateRequest,
+    user: dict = Depends(get_current_user),
+    repo: SupabaseProjectRepository = Depends(_get_repo),
+) -> ProjectResponse:
+    """Update project metadata."""
+    project = repo.get(project_id)
+    if not project or project.get("user_id") != user["id"]:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    update_data = request.model_dump(exclude_none=True)
+    if not update_data:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    updated = repo.update(project_id, update_data)
+    logger.info("project_updated", project_id=project_id)
+    return ProjectResponse(**updated)
+
+
+@router.delete("/{project_id}", status_code=204)
+async def delete_project(
+    project_id: str,
+    user: dict = Depends(get_current_user),
+    repo: SupabaseProjectRepository = Depends(_get_repo),
+) -> None:
+    """Delete project. Tasks are unlinked (project_id set to null)."""
+    project = repo.get(project_id)
+    if not project or project.get("user_id") != user["id"]:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    repo.delete(project_id)
+    logger.info("project_deleted", project_id=project_id, user_id=user["id"])

--- a/src/agent_fleet/api/routes/tasks.py
+++ b/src/agent_fleet/api/routes/tasks.py
@@ -3,7 +3,7 @@
 import uuid
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from agent_fleet.api.deps import get_current_user, get_supabase_client
 from agent_fleet.api.schemas.tasks import TaskListResponse, TaskResponse, TaskSubmitRequest
@@ -33,6 +33,7 @@ async def submit_task(
         repo_path=request.repo,
         description=request.description,
         workflow=str(request.workflow_id),
+        project_id=request.project_id,
     )
 
     logger.info("task_submitted", task_id=task_id, user_id=user["id"])
@@ -43,9 +44,13 @@ async def submit_task(
 async def list_tasks(
     user: dict = Depends(get_current_user),
     repo: SupabaseTaskRepository = Depends(_get_repo),
+    project_id: str | None = Query(None),
 ) -> TaskListResponse:
-    """List all tasks for the current user."""
-    tasks = repo.list_by_user(user["id"])
+    """List tasks for the current user, optionally filtered by project."""
+    if project_id:
+        tasks = repo.list_by_project(user["id"], project_id)
+    else:
+        tasks = repo.list_by_user(user["id"])
     return TaskListResponse(tasks=[TaskResponse(**t) for t in tasks])
 
 

--- a/src/agent_fleet/api/schemas/projects.py
+++ b/src/agent_fleet/api/schemas/projects.py
@@ -1,0 +1,61 @@
+"""Pydantic schemas for project API endpoints."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ProjectCreateRequest(BaseModel):
+    """Request body for POST /api/v1/projects."""
+
+    name: str
+    repo_path: str
+    languages: list[str] = []
+    frameworks: list[str] = []
+    test_frameworks: list[str] = []
+    databases: list[str] = []
+    has_ci: bool = False
+    ci_platform: str | None = None
+    has_docker: bool = False
+    estimated_loc: int | None = None
+
+
+class ProjectUpdateRequest(BaseModel):
+    """Request body for PUT /api/v1/projects/{id}."""
+
+    name: str | None = None
+    repo_path: str | None = None
+    languages: list[str] | None = None
+    frameworks: list[str] | None = None
+    test_frameworks: list[str] | None = None
+    databases: list[str] | None = None
+    has_ci: bool | None = None
+    ci_platform: str | None = None
+    has_docker: bool | None = None
+    estimated_loc: int | None = None
+
+
+class ProjectResponse(BaseModel):
+    """Response body for project endpoints."""
+
+    id: str
+    name: str
+    repo_path: str
+    languages: list[str] = []
+    frameworks: list[str] = []
+    test_frameworks: list[str] = []
+    databases: list[str] = []
+    has_ci: bool = False
+    ci_platform: str | None = None
+    has_docker: bool = False
+    estimated_loc: int | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProjectDetailResponse(ProjectResponse):
+    """Response body for GET /api/v1/projects/{id} — includes task count."""
+
+    task_count: int = 0

--- a/src/agent_fleet/api/schemas/tasks.py
+++ b/src/agent_fleet/api/schemas/tasks.py
@@ -21,6 +21,7 @@ class TaskResponse(BaseModel):
     repo: str
     description: str
     status: str
+    project_id: str | None = None
     workflow_name: str | None = None
     current_stage: str | None = None
     completed_stages: list[str] = []

--- a/src/agent_fleet/main.py
+++ b/src/agent_fleet/main.py
@@ -11,6 +11,7 @@ from agent_fleet.api.routes import (
     audit,
     chat,
     profile,
+    projects,
     tasks,
     webhooks,
     workflows,
@@ -33,6 +34,7 @@ def create_app() -> FastAPI:
 
     # Routes
     app.include_router(tasks.router)
+    app.include_router(projects.router)
     app.include_router(agents.router)
     app.include_router(workflows.router)
     app.include_router(profile.router)

--- a/src/agent_fleet/store/supabase_repo.py
+++ b/src/agent_fleet/store/supabase_repo.py
@@ -58,6 +58,16 @@ class SupabaseTaskRepository:
         result = self._client.table("tasks").select("*").eq("status", status).execute()
         return result.data
 
+    def count_by_project(self, project_id: str) -> int:
+        """Count tasks for a project."""
+        result = (
+            self._client.table("tasks")
+            .select("id", count="exact")
+            .eq("project_id", project_id)
+            .execute()
+        )
+        return result.count or 0
+
     def atomic_pickup(self, task_id: str) -> bool:
         """Atomically claim a queued task. Returns True if this worker won the race."""
         from datetime import datetime
@@ -256,3 +266,51 @@ class SupabaseWorkflowRepository:
     def delete(self, workflow_id: str) -> None:
         self._client.table("workflows").delete().eq("id", workflow_id).execute()
         logger.info("workflow_deleted", workflow_id=workflow_id)
+
+
+class SupabaseProjectRepository:
+    """Project CRUD via Supabase."""
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    def create(self, user_id: str, data: dict) -> dict:
+        """Create a project for a user."""
+        data["user_id"] = user_id
+        result = self._client.table("projects").insert(data).execute()
+        return result.data[0]
+
+    def get(self, project_id: str) -> dict | None:
+        """Get project by ID."""
+        result = (
+            self._client.table("projects")
+            .select("*")
+            .eq("id", project_id)
+            .execute()
+        )
+        return result.data[0] if result.data else None
+
+    def list_by_user(self, user_id: str) -> list[dict]:
+        """List all projects for a user, newest first."""
+        result = (
+            self._client.table("projects")
+            .select("*")
+            .eq("user_id", user_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return result.data
+
+    def update(self, project_id: str, data: dict) -> dict:
+        """Update project metadata."""
+        result = (
+            self._client.table("projects")
+            .update(data)
+            .eq("id", project_id)
+            .execute()
+        )
+        return result.data[0]
+
+    def delete(self, project_id: str) -> None:
+        """Delete project. Tasks are unlinked via ON DELETE SET NULL."""
+        self._client.table("projects").delete().eq("id", project_id).execute()

--- a/src/agent_fleet/store/supabase_repo.py
+++ b/src/agent_fleet/store/supabase_repo.py
@@ -16,7 +16,13 @@ class SupabaseTaskRepository:
         self._client = client
 
     def create(
-        self, task_id: str, user_id: str, repo_path: str, description: str, workflow: str
+        self,
+        task_id: str,
+        user_id: str,
+        repo_path: str,
+        description: str,
+        workflow: str,
+        project_id: str | None = None,
     ) -> dict:
         result = (
             self._client.table("tasks")
@@ -28,6 +34,7 @@ class SupabaseTaskRepository:
                     "description": description,
                     "workflow_name": workflow,
                     "status": "queued",
+                    "project_id": project_id,
                 }
             )
             .execute()
@@ -56,6 +63,18 @@ class SupabaseTaskRepository:
 
     def list_by_status(self, status: str) -> list[dict]:
         result = self._client.table("tasks").select("*").eq("status", status).execute()
+        return result.data
+
+    def list_by_project(self, user_id: str, project_id: str) -> list[dict]:
+        """List tasks for a project, scoped to user."""
+        result = (
+            self._client.table("tasks")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("project_id", project_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
         return result.data
 
     def count_by_project(self, project_id: str) -> int:

--- a/src/agent_fleet/store/supabase_repo.py
+++ b/src/agent_fleet/store/supabase_repo.py
@@ -301,12 +301,7 @@ class SupabaseProjectRepository:
 
     def get(self, project_id: str) -> dict | None:
         """Get project by ID."""
-        result = (
-            self._client.table("projects")
-            .select("*")
-            .eq("id", project_id)
-            .execute()
-        )
+        result = self._client.table("projects").select("*").eq("id", project_id).execute()
         return result.data[0] if result.data else None
 
     def list_by_user(self, user_id: str) -> list[dict]:
@@ -322,12 +317,7 @@ class SupabaseProjectRepository:
 
     def update(self, project_id: str, data: dict) -> dict:
         """Update project metadata."""
-        result = (
-            self._client.table("projects")
-            .update(data)
-            .eq("id", project_id)
-            .execute()
-        )
+        result = self._client.table("projects").update(data).eq("id", project_id).execute()
         return result.data[0]
 
     def delete(self, project_id: str) -> None:

--- a/supabase/migrations/20260330000000_add_project_id_to_tasks.sql
+++ b/supabase/migrations/20260330000000_add_project_id_to_tasks.sql
@@ -1,0 +1,8 @@
+-- Add project_id FK to tasks table
+ALTER TABLE tasks ADD COLUMN project_id UUID REFERENCES projects(id) ON DELETE SET NULL;
+CREATE INDEX idx_tasks_project_id ON tasks(project_id);
+
+-- Add updated_at trigger for projects (function already exists from initial schema)
+CREATE TRIGGER update_projects_updated_at
+  BEFORE UPDATE ON projects
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/tests/unit/test_api_tasks.py
+++ b/tests/unit/test_api_tasks.py
@@ -160,6 +160,78 @@ class TestGetTask:
         assert response.status_code == 404
 
 
+class TestSubmitWithProject:
+    def test_submit_with_project_id(self, client: TestClient, mock_repo: MagicMock) -> None:
+        """POST /api/v1/tasks with project_id passes it to create."""
+        mock_repo.create.return_value = {
+            "id": "task-proj",
+            "repo": "/tmp/repo",
+            "description": "Task",
+            "status": "queued",
+            "workflow_name": "default",
+            "project_id": "proj-1",
+            "created_at": "2026-03-30T00:00:00Z",
+            "updated_at": "2026-03-30T00:00:00Z",
+        }
+        response = client.post(
+            "/api/v1/tasks",
+            json={"repo": "/tmp/repo", "description": "Task", "workflow_id": "wf-1", "project_id": "proj-1"},
+        )
+        assert response.status_code == 201
+        call_kwargs = mock_repo.create.call_args
+        assert call_kwargs.kwargs.get("project_id") == "proj-1"
+
+    def test_submit_without_project_id_passes_none(
+        self, client: TestClient, mock_repo: MagicMock
+    ) -> None:
+        """POST /api/v1/tasks without project_id passes None."""
+        mock_repo.create.return_value = {
+            "id": "task-no-proj",
+            "repo": "/tmp/repo",
+            "description": "Task",
+            "status": "queued",
+            "workflow_name": "default",
+            "project_id": None,
+            "created_at": "2026-03-30T00:00:00Z",
+            "updated_at": "2026-03-30T00:00:00Z",
+        }
+        client.post(
+            "/api/v1/tasks",
+            json={"repo": "/tmp/repo", "description": "Task", "workflow_id": "wf-1"},
+        )
+        call_kwargs = mock_repo.create.call_args
+        assert call_kwargs.kwargs.get("project_id") is None
+
+
+class TestListByProject:
+    def test_list_with_project_filter(self, client: TestClient, mock_repo: MagicMock) -> None:
+        """GET /api/v1/tasks?project_id=X calls list_by_project."""
+        mock_repo.list_by_project.return_value = [
+            {
+                "id": "t-1",
+                "repo": "/tmp",
+                "description": "Task",
+                "status": "completed",
+                "project_id": "proj-1",
+                "created_at": "2026-03-30T00:00:00Z",
+                "updated_at": "2026-03-30T00:00:00Z",
+            }
+        ]
+        response = client.get("/api/v1/tasks?project_id=proj-1")
+        assert response.status_code == 200
+        mock_repo.list_by_project.assert_called_once_with("user-123", "proj-1")
+
+    def test_list_without_project_filter_uses_list_by_user(
+        self, client: TestClient, mock_repo: MagicMock
+    ) -> None:
+        """GET /api/v1/tasks without project_id calls list_by_user."""
+        mock_repo.list_by_user.return_value = []
+        response = client.get("/api/v1/tasks")
+        assert response.status_code == 200
+        mock_repo.list_by_user.assert_called_once()
+        mock_repo.list_by_project.assert_not_called()
+
+
 class TestCancelTask:
     def test_cancel_sets_cancelled(self, client: TestClient, mock_repo: MagicMock) -> None:
         """DELETE /api/v1/tasks/{id}/cancel sets status to cancelled."""

--- a/tests/unit/test_api_tasks.py
+++ b/tests/unit/test_api_tasks.py
@@ -175,7 +175,12 @@ class TestSubmitWithProject:
         }
         response = client.post(
             "/api/v1/tasks",
-            json={"repo": "/tmp/repo", "description": "Task", "workflow_id": "wf-1", "project_id": "proj-1"},
+            json={
+                "repo": "/tmp/repo",
+                "description": "Task",
+                "workflow_id": "wf-1",
+                "project_id": "proj-1",
+            },
         )
         assert response.status_code == 201
         call_kwargs = mock_repo.create.call_args
@@ -257,7 +262,9 @@ class TestCancelTask:
         assert response.status_code == 400
 
     def test_cancel_already_cancelled_returns_400(
-        self, client: TestClient, mock_repo: MagicMock,
+        self,
+        client: TestClient,
+        mock_repo: MagicMock,
     ) -> None:
         """DELETE /api/v1/tasks/{id}/cancel returns 400 if task is already cancelled."""
         mock_repo.get.return_value = {

--- a/tests/unit/test_checkpointer.py
+++ b/tests/unit/test_checkpointer.py
@@ -9,10 +9,13 @@ from agent_fleet.worker.checkpointer import get_checkpointer
 
 def test_get_checkpointer_creates_saver_with_db_url():
     """Creates PostgresSaver using SUPABASE_DB_URL env var."""
-    with patch.dict(
-        "os.environ",
-        {"SUPABASE_DB_URL": "postgresql://postgres:pass@db.example.com:5432/postgres"},
-    ), patch("agent_fleet.worker.checkpointer.PostgresSaver") as mock_cls:
+    with (
+        patch.dict(
+            "os.environ",
+            {"SUPABASE_DB_URL": "postgresql://postgres:pass@db.example.com:5432/postgres"},
+        ),
+        patch("agent_fleet.worker.checkpointer.PostgresSaver") as mock_cls,
+    ):
         mock_saver = MagicMock()
         mock_cls.from_conn_string.return_value = mock_saver
 
@@ -33,10 +36,13 @@ def test_get_checkpointer_raises_when_not_configured():
 
 def test_get_checkpointer_calls_setup():
     """Calls setup() on the saver to create checkpoint tables."""
-    with patch.dict(
-        "os.environ",
-        {"SUPABASE_DB_URL": "postgresql://postgres:pass@localhost:5432/postgres"},
-    ), patch("agent_fleet.worker.checkpointer.PostgresSaver") as mock_cls:
+    with (
+        patch.dict(
+            "os.environ",
+            {"SUPABASE_DB_URL": "postgresql://postgres:pass@localhost:5432/postgres"},
+        ),
+        patch("agent_fleet.worker.checkpointer.PostgresSaver") as mock_cls,
+    ):
         mock_saver = MagicMock()
         mock_cls.from_conn_string.return_value = mock_saver
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -122,11 +122,18 @@ def test_build_graph_passes_checkpointer():
         name="test",
         stages=[StageConfig(name="plan", agent="Arch", gate=GateConfig(type="approval"))],
     )
-    registry = AgentRegistry.from_configs([{
-        "name": "Arch", "description": "Plans", "capabilities": ["code_analysis"],
-        "tools": ["code"], "default_model": "anthropic/claude-opus-4-6",
-        "system_prompt": "You are an architect.",
-    }])
+    registry = AgentRegistry.from_configs(
+        [
+            {
+                "name": "Arch",
+                "description": "Plans",
+                "capabilities": ["code_analysis"],
+                "tools": ["code"],
+                "default_model": "anthropic/claude-opus-4-6",
+                "system_prompt": "You are an architect.",
+            }
+        ]
+    )
 
     orch = FleetOrchestrator(task_id="t-1", workflow=workflow, registry=registry)
     mock_checkpointer = MagicMock()
@@ -151,11 +158,18 @@ def test_build_graph_works_without_checkpointer():
         name="test",
         stages=[StageConfig(name="plan", agent="Arch", gate=GateConfig(type="approval"))],
     )
-    registry = AgentRegistry.from_configs([{
-        "name": "Arch", "description": "Plans", "capabilities": ["code_analysis"],
-        "tools": ["code"], "default_model": "anthropic/claude-opus-4-6",
-        "system_prompt": "You are an architect.",
-    }])
+    registry = AgentRegistry.from_configs(
+        [
+            {
+                "name": "Arch",
+                "description": "Plans",
+                "capabilities": ["code_analysis"],
+                "tools": ["code"],
+                "default_model": "anthropic/claude-opus-4-6",
+                "system_prompt": "You are an architect.",
+            }
+        ]
+    )
 
     orch = FleetOrchestrator(task_id="t-1", workflow=workflow, registry=registry)
 

--- a/tests/unit/test_project_repo.py
+++ b/tests/unit/test_project_repo.py
@@ -26,7 +26,9 @@ class TestProjectRepoGet:
         """Get returns project dict."""
         client = MagicMock()
         row = {"id": "proj-1", "name": "My Project"}
-        client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [row]
+        (
+            client.table.return_value.select.return_value.eq.return_value.execute.return_value.data
+        ) = [row]
 
         repo = SupabaseProjectRepository(client)
         result = repo.get("proj-1")
@@ -59,7 +61,9 @@ class TestProjectRepoUpdate:
         """Update sends data dict to Supabase."""
         client = MagicMock()
         row = {"id": "proj-1", "name": "Updated"}
-        client.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [row]
+        (
+            client.table.return_value.update.return_value.eq.return_value.execute.return_value.data
+        ) = [row]
 
         repo = SupabaseProjectRepository(client)
         result = repo.update("proj-1", {"name": "Updated"})

--- a/tests/unit/test_project_repo.py
+++ b/tests/unit/test_project_repo.py
@@ -1,0 +1,77 @@
+"""Tests for SupabaseProjectRepository."""
+
+from unittest.mock import MagicMock
+
+from agent_fleet.store.supabase_repo import SupabaseProjectRepository
+
+
+class TestProjectRepoCreate:
+    def test_create_inserts_with_user_id(self):
+        """Create project inserts user_id and data."""
+        client = MagicMock()
+        row = {"id": "proj-1", "name": "My Project", "user_id": "user-1"}
+        client.table.return_value.insert.return_value.execute.return_value.data = [row]
+
+        repo = SupabaseProjectRepository(client)
+        result = repo.create("user-1", {"name": "My Project", "repo_path": "/tmp/repo"})
+
+        insert_payload = client.table.return_value.insert.call_args[0][0]
+        assert insert_payload["user_id"] == "user-1"
+        assert insert_payload["name"] == "My Project"
+        assert result == row
+
+
+class TestProjectRepoGet:
+    def test_get_returns_project(self):
+        """Get returns project dict."""
+        client = MagicMock()
+        row = {"id": "proj-1", "name": "My Project"}
+        client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [row]
+
+        repo = SupabaseProjectRepository(client)
+        result = repo.get("proj-1")
+        assert result == row
+
+    def test_get_returns_none_when_missing(self):
+        """Get returns None when project not found."""
+        client = MagicMock()
+        client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = []
+
+        repo = SupabaseProjectRepository(client)
+        assert repo.get("nonexistent") is None
+
+
+class TestProjectRepoListByUser:
+    def test_list_returns_user_projects(self):
+        """List returns projects ordered by created_at desc."""
+        client = MagicMock()
+        rows = [{"id": "p1"}, {"id": "p2"}]
+        chain = client.table.return_value.select.return_value
+        chain.eq.return_value.order.return_value.execute.return_value.data = rows
+
+        repo = SupabaseProjectRepository(client)
+        result = repo.list_by_user("user-1")
+        assert result == rows
+
+
+class TestProjectRepoUpdate:
+    def test_update_sends_data(self):
+        """Update sends data dict to Supabase."""
+        client = MagicMock()
+        row = {"id": "proj-1", "name": "Updated"}
+        client.table.return_value.update.return_value.eq.return_value.execute.return_value.data = [row]
+
+        repo = SupabaseProjectRepository(client)
+        result = repo.update("proj-1", {"name": "Updated"})
+        assert result == row
+
+
+class TestProjectRepoDelete:
+    def test_delete_removes_project(self):
+        """Delete calls Supabase delete."""
+        client = MagicMock()
+        client.table.return_value.delete.return_value.eq.return_value.execute.return_value.data = []
+
+        repo = SupabaseProjectRepository(client)
+        repo.delete("proj-1")
+        client.table.assert_called_with("projects")

--- a/tests/unit/test_projects_route.py
+++ b/tests/unit/test_projects_route.py
@@ -113,9 +113,7 @@ class TestGetProject:
 
 
 class TestUpdateProject:
-    def test_updates_project(
-        self, client: TestClient, mock_repo: MagicMock
-    ) -> None:
+    def test_updates_project(self, client: TestClient, mock_repo: MagicMock) -> None:
         mock_repo.get.return_value = PROJECT_ROW
         mock_repo.update.return_value = {**PROJECT_ROW, "name": "Updated"}
         resp = client.put("/api/v1/projects/p1", json={"name": "Updated"})

--- a/tests/unit/test_projects_route.py
+++ b/tests/unit/test_projects_route.py
@@ -1,0 +1,146 @@
+"""Tests for project API routes."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_fleet.api.deps import get_current_user
+from agent_fleet.api.routes.projects import _get_repo, _get_task_repo
+from agent_fleet.main import create_app
+
+TEST_USER = {"id": "user-123", "email": "test@example.com"}
+
+PROJECT_ROW = {
+    "id": "p1",
+    "user_id": "user-123",
+    "name": "My Project",
+    "repo_path": "/tmp/repo",
+    "languages": ["python"],
+    "frameworks": [],
+    "test_frameworks": [],
+    "databases": [],
+    "has_ci": False,
+    "ci_platform": None,
+    "has_docker": False,
+    "estimated_loc": None,
+    "created_at": "2026-03-29T00:00:00Z",
+    "updated_at": "2026-03-29T00:00:00Z",
+}
+
+
+@pytest.fixture
+def mock_repo() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_task_repo() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(mock_repo: MagicMock, mock_task_repo: MagicMock) -> TestClient:
+    app = create_app()
+
+    async def _fake_user() -> dict:
+        return TEST_USER
+
+    app.dependency_overrides[get_current_user] = _fake_user
+    app.dependency_overrides[_get_repo] = lambda: mock_repo
+    app.dependency_overrides[_get_task_repo] = lambda: mock_task_repo
+    return TestClient(app)
+
+
+class TestListProjects:
+    def test_returns_user_projects(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.list_by_user.return_value = [PROJECT_ROW]
+        resp = client.get("/api/v1/projects")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "My Project"
+
+    def test_empty_list(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.list_by_user.return_value = []
+        resp = client.get("/api/v1/projects")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_scoped_to_user(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.list_by_user.return_value = []
+        client.get("/api/v1/projects")
+        mock_repo.list_by_user.assert_called_once_with("user-123")
+
+
+class TestCreateProject:
+    def test_creates_project(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.create.return_value = PROJECT_ROW
+        resp = client.post(
+            "/api/v1/projects",
+            json={"name": "My Project", "repo_path": "/tmp/repo", "languages": ["python"]},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "My Project"
+
+    def test_missing_name_returns_422(self, client: TestClient, mock_repo: MagicMock) -> None:
+        resp = client.post("/api/v1/projects", json={"repo_path": "/tmp"})
+        assert resp.status_code == 422
+
+    def test_missing_repo_path_returns_422(self, client: TestClient, mock_repo: MagicMock) -> None:
+        resp = client.post("/api/v1/projects", json={"name": "Test"})
+        assert resp.status_code == 422
+
+
+class TestGetProject:
+    def test_returns_project_with_task_count(
+        self, client: TestClient, mock_repo: MagicMock, mock_task_repo: MagicMock
+    ) -> None:
+        mock_repo.get.return_value = PROJECT_ROW
+        mock_task_repo.count_by_project.return_value = 5
+        resp = client.get("/api/v1/projects/p1")
+        assert resp.status_code == 200
+        assert resp.json()["task_count"] == 5
+
+    def test_404_for_missing(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.get.return_value = None
+        resp = client.get("/api/v1/projects/nonexistent")
+        assert resp.status_code == 404
+
+    def test_404_for_other_user(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.get.return_value = {**PROJECT_ROW, "user_id": "other-user"}
+        resp = client.get("/api/v1/projects/p1")
+        assert resp.status_code == 404
+
+
+class TestUpdateProject:
+    def test_updates_project(
+        self, client: TestClient, mock_repo: MagicMock
+    ) -> None:
+        mock_repo.get.return_value = PROJECT_ROW
+        mock_repo.update.return_value = {**PROJECT_ROW, "name": "Updated"}
+        resp = client.put("/api/v1/projects/p1", json={"name": "Updated"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Updated"
+
+    def test_empty_update_returns_400(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.get.return_value = PROJECT_ROW
+        resp = client.put("/api/v1/projects/p1", json={})
+        assert resp.status_code == 400
+
+    def test_404_for_other_user(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.get.return_value = {**PROJECT_ROW, "user_id": "other-user"}
+        resp = client.put("/api/v1/projects/p1", json={"name": "X"})
+        assert resp.status_code == 404
+
+
+class TestDeleteProject:
+    def test_deletes_project(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.get.return_value = PROJECT_ROW
+        resp = client.delete("/api/v1/projects/p1")
+        assert resp.status_code == 204
+        mock_repo.delete.assert_called_once_with("p1")
+
+    def test_404_for_other_user(self, client: TestClient, mock_repo: MagicMock) -> None:
+        mock_repo.get.return_value = {**PROJECT_ROW, "user_id": "other-user"}
+        resp = client.delete("/api/v1/projects/p1")
+        assert resp.status_code == 404

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -16,8 +16,10 @@ def mock_service_client():
 
 @pytest.fixture
 def worker(mock_service_client):
-    with patch("agent_fleet.worker.get_service_client", return_value=mock_service_client), \
-         patch("agent_fleet.worker.get_checkpointer") as mock_cp:
+    with (
+        patch("agent_fleet.worker.get_service_client", return_value=mock_service_client),
+        patch("agent_fleet.worker.get_checkpointer") as mock_cp,
+    ):
         mock_cp.return_value = MagicMock()
         w = FleetWorker(max_concurrent_tasks=2, poll_interval_seconds=0.1)
         yield w

--- a/tests/unit/test_worker_resume.py
+++ b/tests/unit/test_worker_resume.py
@@ -14,8 +14,10 @@ def mock_service_client():
 
 @pytest.fixture
 def worker(mock_service_client):
-    with patch("agent_fleet.worker.get_service_client", return_value=mock_service_client), \
-         patch("agent_fleet.worker.get_checkpointer") as mock_cp:
+    with (
+        patch("agent_fleet.worker.get_service_client", return_value=mock_service_client),
+        patch("agent_fleet.worker.get_checkpointer") as mock_cp,
+    ):
         mock_cp.return_value = MagicMock()
         w = FleetWorker(max_concurrent_tasks=2, poll_interval_seconds=0.1)
         yield w
@@ -25,16 +27,23 @@ def worker(mock_service_client):
 class TestResumeLogic:
     def _make_task(self, status="queued"):
         return {
-            "id": "task-resume", "repo": "/tmp/repo", "description": "Do something",
-            "workflow_id": "wf-1", "user_id": "user-1", "status": status,
+            "id": "task-resume",
+            "repo": "/tmp/repo",
+            "description": "Do something",
+            "workflow_id": "wf-1",
+            "user_id": "user-1",
+            "status": status,
         }
 
     def test_fresh_task_invokes_with_initial_state(self, worker):
         """Queued task calls graph.invoke(initial_state, config)."""
         task = self._make_task(status="queued")
-        worker._workflows_repo.get = MagicMock(return_value={
-            "name": "wf", "stages": [{"name": "plan", "agent": "Arch"}],
-        })
+        worker._workflows_repo.get = MagicMock(
+            return_value={
+                "name": "wf",
+                "stages": [{"name": "plan", "agent": "Arch"}],
+            }
+        )
         worker._agents_repo.list_by_user = MagicMock(return_value=[])
         worker._tasks_repo.update_status = MagicMock()
         worker._events_repo.append = MagicMock()
@@ -44,8 +53,10 @@ class TestResumeLogic:
         mock_writer = MagicMock()
         mock_writer.build_graph.return_value = mock_graph
 
-        with patch("agent_fleet.worker.OrchestratorFactory") as mock_factory, \
-             patch("agent_fleet.worker.WorktreeManager"):
+        with (
+            patch("agent_fleet.worker.OrchestratorFactory") as mock_factory,
+            patch("agent_fleet.worker.WorktreeManager"),
+        ):
             mock_factory.from_supabase.return_value = mock_writer
             worker._execute_task(task)
 
@@ -56,9 +67,12 @@ class TestResumeLogic:
     def test_resuming_task_checks_checkpoint(self, worker):
         """Resuming task calls graph.get_state() and resumes if checkpoint exists."""
         task = self._make_task(status="resuming")
-        worker._workflows_repo.get = MagicMock(return_value={
-            "name": "wf", "stages": [{"name": "plan", "agent": "Arch"}],
-        })
+        worker._workflows_repo.get = MagicMock(
+            return_value={
+                "name": "wf",
+                "stages": [{"name": "plan", "agent": "Arch"}],
+            }
+        )
         worker._agents_repo.list_by_user = MagicMock(return_value=[])
         worker._tasks_repo.update_status = MagicMock()
         worker._events_repo.append = MagicMock()
@@ -71,8 +85,10 @@ class TestResumeLogic:
         mock_writer = MagicMock()
         mock_writer.build_graph.return_value = mock_graph
 
-        with patch("agent_fleet.worker.OrchestratorFactory") as mock_factory, \
-             patch("agent_fleet.worker.WorktreeManager"):
+        with (
+            patch("agent_fleet.worker.OrchestratorFactory") as mock_factory,
+            patch("agent_fleet.worker.WorktreeManager"),
+        ):
             mock_factory.from_supabase.return_value = mock_writer
             worker._execute_task(task)
 
@@ -83,9 +99,12 @@ class TestResumeLogic:
     def test_resuming_no_checkpoint_falls_back_to_fresh(self, worker):
         """Resuming task with no checkpoint starts fresh."""
         task = self._make_task(status="resuming")
-        worker._workflows_repo.get = MagicMock(return_value={
-            "name": "wf", "stages": [{"name": "plan", "agent": "Arch"}],
-        })
+        worker._workflows_repo.get = MagicMock(
+            return_value={
+                "name": "wf",
+                "stages": [{"name": "plan", "agent": "Arch"}],
+            }
+        )
         worker._agents_repo.list_by_user = MagicMock(return_value=[])
         worker._tasks_repo.update_status = MagicMock()
         worker._events_repo.append = MagicMock()
@@ -98,8 +117,10 @@ class TestResumeLogic:
         mock_writer = MagicMock()
         mock_writer.build_graph.return_value = mock_graph
 
-        with patch("agent_fleet.worker.OrchestratorFactory") as mock_factory, \
-             patch("agent_fleet.worker.WorktreeManager"):
+        with (
+            patch("agent_fleet.worker.OrchestratorFactory") as mock_factory,
+            patch("agent_fleet.worker.WorktreeManager"),
+        ):
             mock_factory.from_supabase.return_value = mock_writer
             worker._execute_task(task)
 
@@ -111,16 +132,23 @@ class TestResumeLogic:
 class TestCheckpointCleanup:
     def _make_task(self, status="queued"):
         return {
-            "id": "task-done", "repo": "/tmp/repo", "description": "x",
-            "workflow_id": "wf-1", "user_id": "u-1", "status": status,
+            "id": "task-done",
+            "repo": "/tmp/repo",
+            "description": "x",
+            "workflow_id": "wf-1",
+            "user_id": "u-1",
+            "status": status,
         }
 
     def test_checkpoint_cleaned_after_completion(self, worker):
         """Checkpoint is deleted after task completes successfully."""
         task = self._make_task()
-        worker._workflows_repo.get = MagicMock(return_value={
-            "name": "wf", "stages": [{"name": "plan", "agent": "Arch"}],
-        })
+        worker._workflows_repo.get = MagicMock(
+            return_value={
+                "name": "wf",
+                "stages": [{"name": "plan", "agent": "Arch"}],
+            }
+        )
         worker._agents_repo.list_by_user = MagicMock(return_value=[])
         worker._tasks_repo.update_status = MagicMock()
         worker._events_repo.append = MagicMock()
@@ -130,8 +158,10 @@ class TestCheckpointCleanup:
         mock_writer = MagicMock()
         mock_writer.build_graph.return_value = mock_graph
 
-        with patch("agent_fleet.worker.OrchestratorFactory") as mock_factory, \
-             patch("agent_fleet.worker.WorktreeManager"):
+        with (
+            patch("agent_fleet.worker.OrchestratorFactory") as mock_factory,
+            patch("agent_fleet.worker.WorktreeManager"),
+        ):
             mock_factory.from_supabase.return_value = mock_writer
             worker._execute_task(task)
 
@@ -152,9 +182,12 @@ class TestCheckpointCleanup:
     def test_checkpoint_cleanup_failure_is_non_fatal(self, worker):
         """If checkpoint cleanup fails, task still completes normally."""
         task = self._make_task()
-        worker._workflows_repo.get = MagicMock(return_value={
-            "name": "wf", "stages": [{"name": "plan", "agent": "Arch"}],
-        })
+        worker._workflows_repo.get = MagicMock(
+            return_value={
+                "name": "wf",
+                "stages": [{"name": "plan", "agent": "Arch"}],
+            }
+        )
         worker._agents_repo.list_by_user = MagicMock(return_value=[])
         worker._tasks_repo.update_status = MagicMock()
         worker._events_repo.append = MagicMock()
@@ -165,8 +198,10 @@ class TestCheckpointCleanup:
         mock_writer.build_graph.return_value = mock_graph
         worker._checkpointer.delete_thread.side_effect = RuntimeError("DB gone")
 
-        with patch("agent_fleet.worker.OrchestratorFactory") as mock_factory, \
-             patch("agent_fleet.worker.WorktreeManager"):
+        with (
+            patch("agent_fleet.worker.OrchestratorFactory") as mock_factory,
+            patch("agent_fleet.worker.WorktreeManager"),
+        ):
             mock_factory.from_supabase.return_value = mock_writer
             worker._execute_task(task)
 


### PR DESCRIPTION
## Summary

- **Migration**: adds `project_id` FK + index on `tasks`, and `updated_at` trigger on `projects`
- **Backend**: `SupabaseProjectRepository` (create/get/list/update/delete), `count_by_project` + `list_by_project` on `SupabaseTaskRepository`, full `/api/v1/projects` CRUD routes with user-scoping, `project_id` wired through task creation and listing
- **UI**: project cards now link to a detail page with clickable task history; edit (rename) and delete (with confirmation) actions on cards; new `ProjectDetail` page; optional project selector on `SubmitTask` form (pre-fills repo path and supports `?project_id=` deep-link)
- **Tests**: 6 repo unit tests, 14 route unit tests, 4 task route tests — 340 total passing; ruff lint + format clean

## Test plan

- [ ] `pytest tests/unit/ -v` — all 340 tests pass
- [ ] `ruff check src/ cli/ tests/` — no errors
- [ ] UI: add a project, click its card → ProjectDetail page loads with metadata
- [ ] UI: submit a task from ProjectDetail → task appears in the project task list
- [ ] UI: rename a project via edit button → card updates
- [ ] UI: delete a project → card removed, linked tasks unaffected
- [ ] API: `POST /api/v1/projects` → 201 with project payload
- [ ] API: `GET /api/v1/tasks?project_id=<id>` → filters correctly
- [ ] Apply migration: `supabase/migrations/20260330000000_add_project_id_to_tasks.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)